### PR TITLE
:sparkles: S3 이미지 다운로드 기능 추가

### DIFF
--- a/src/main/java/com/example/harmony/global/s3/S3Service.java
+++ b/src/main/java/com/example/harmony/global/s3/S3Service.java
@@ -3,12 +3,12 @@ package com.example.harmony.global.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MimeType;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -25,11 +25,10 @@ public class S3Service {
     private String bucket;
 
     public UploadResponse uploadFile(MultipartFile file) {
-        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(file.getContentType());
+        MimeType mimeType = MimeType.valueOf(file.getContentType());
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename() + "." + mimeType.getSubtype();
         try {
-            PutObjectRequest por = new PutObjectRequest(bucket, filename, file.getInputStream(), metadata)
+            PutObjectRequest por = new PutObjectRequest(bucket, filename, file.getInputStream(), null)
                     .withCannedAcl(CannedAccessControlList.PublicRead);
             amazonS3.putObject(por);
         } catch (Exception e) {


### PR DESCRIPTION
- S3 버킷에 이미지 파일을 업로드할 때 메타데이터를 application/octet-stream으로 하고 파일명에 .png 등을 붙여서 저장