### PR TITLE
:bug: 연동된 갤러리가 존재하는 일정 삭제 버그 해결

### DIFF
--- a/src/main/java/com/example/harmony/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/harmony/domain/schedule/service/ScheduleService.java
@@ -82,6 +82,9 @@ public class ScheduleService {
         if (!schedule.getFamily().getId().equals(user.getFamily().getId())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "일정 삭제 권한이 없습니다");
         }
+        if (schedule.getGalleries().size() > 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "일정에 연동된 갤러리가 있습니다");
+        }
         scheduleRepository.deleteById(scheduleId);
 
         if (schedule.isDone() && schedule.getParticipations().size() >= 2) {


### PR DESCRIPTION
- cascade 옵션을 주지않아서 연동된 갤러리가 존재하는 일정은 삭제 불가능한 버그 발견
- 회의 결과 연동된 갤러리가 존재하는 일정은 그대로 삭제가 불가능하게하고 에러메시지를 띄우는것으로 결정