### PR TITLE
:bug: 갤러리 댓글 작성자 유무 버그 해결

### DIFF
--- a/src/main/java/com/example/harmony/domain/gallery/dto/CommentResponse.java
+++ b/src/main/java/com/example/harmony/domain/gallery/dto/CommentResponse.java
@@ -15,7 +15,7 @@ public class CommentResponse {
 
     private String commenter;
 
-    private boolean isCommenter;
+    private Boolean isCommenter;
 
     private LocalDate createdAt;
 


### PR DESCRIPTION
- 일정별 갤러리 조회시 댓글 작성자 유무 정보가 안보내지는 버그 발생
- Lombok @Getter 어노테이션의 boolean 변수에 대한 Getter 생성 방식때문에 발생
- boolean -> Boolean 타입 변경